### PR TITLE
Add Zenn-style markdown directives support

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -5,11 +5,12 @@ import mermaid from 'astro-mermaid';
 import react from '@astrojs/react';
 import remarkPerplexitySearch from './src/plugins/remark-google-search.ts';
 import rehypeTableWrapper from './src/plugins/rehype-table-wrapper.ts';
+import remarkZennDirectives, { remarkDirective } from './src/plugins/remark-zenn-directives.ts';
 
 // https://astro.build/config
 export default defineConfig({
 	markdown: {
-		remarkPlugins: [remarkPerplexitySearch],
+		remarkPlugins: [remarkDirective, remarkZennDirectives, remarkPerplexitySearch],
 		rehypePlugins: [rehypeTableWrapper],
 	},
 	integrations: [

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -16,6 +16,7 @@
         "react": "^19.2.3",
         "react-dom": "^19.2.3",
         "react-zoom-pan-pinch": "^3.7.0",
+        "remark-directive": "^4.0.0",
         "sharp": "^0.34.2"
       },
       "devDependencies": {
@@ -564,6 +565,41 @@
       },
       "peerDependencies": {
         "astro": "^5.5.0"
+      }
+    },
+    "node_modules/@astrojs/starlight/node_modules/micromark-extension-directive": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-extension-directive/-/micromark-extension-directive-3.0.2.tgz",
+      "integrity": "sha512-wjcXHgk+PPdmvR58Le9d7zQYWy+vKEU9Se44p2CrCDPiLr2FMyiT4Fyb5UFKFC66wGB3kPlgD7q3TnoqPS7SZA==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "parse-entities": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@astrojs/starlight/node_modules/remark-directive": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/remark-directive/-/remark-directive-3.0.1.tgz",
+      "integrity": "sha512-gwglrEQEZcZYgVyG1tQuA+h58EZfq5CSULw7J90AFuCTyib1thgHPoqQ+h9iFvU6R+vnZ5oNFQR5QKgGpk741A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-directive": "^3.0.0",
+        "micromark-extension-directive": "^3.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/@astrojs/telemetry": {
@@ -6720,9 +6756,9 @@
       }
     },
     "node_modules/micromark-extension-directive": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/micromark-extension-directive/-/micromark-extension-directive-3.0.2.tgz",
-      "integrity": "sha512-wjcXHgk+PPdmvR58Le9d7zQYWy+vKEU9Se44p2CrCDPiLr2FMyiT4Fyb5UFKFC66wGB3kPlgD7q3TnoqPS7SZA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-directive/-/micromark-extension-directive-4.0.0.tgz",
+      "integrity": "sha512-/C2nqVmXXmiseSSuCdItCMho7ybwwop6RrrRPk0KbOHW21JKoCldC+8rFOaundDoRBUWBnJJcxeA/Kvi34WQXg==",
       "license": "MIT",
       "dependencies": {
         "devlop": "^1.0.0",
@@ -8102,14 +8138,14 @@
       }
     },
     "node_modules/remark-directive": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/remark-directive/-/remark-directive-3.0.1.tgz",
-      "integrity": "sha512-gwglrEQEZcZYgVyG1tQuA+h58EZfq5CSULw7J90AFuCTyib1thgHPoqQ+h9iFvU6R+vnZ5oNFQR5QKgGpk741A==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/remark-directive/-/remark-directive-4.0.0.tgz",
+      "integrity": "sha512-7sxn4RfF1o3izevPV1DheyGDD6X4c9hrGpfdUpm7uC++dqrnJxIZVkk7CoKqcLm0VUMAuOol7Mno3m6g8cfMuA==",
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
         "mdast-util-directive": "^3.0.0",
-        "micromark-extension-directive": "^3.0.0",
+        "micromark-extension-directive": "^4.0.0",
         "unified": "^11.0.0"
       },
       "funding": {

--- a/site/package.json
+++ b/site/package.json
@@ -19,6 +19,7 @@
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
     "react-zoom-pan-pinch": "^3.7.0",
+    "remark-directive": "^4.0.0",
     "sharp": "^0.34.2"
   },
   "devDependencies": {

--- a/site/src/content/docs/samples/zenn-syntax-test.md
+++ b/site/src/content/docs/samples/zenn-syntax-test.md
@@ -1,0 +1,100 @@
+---
+title: Zenn記法テスト
+---
+
+# Zenn記法のテスト
+
+このページでは、Zenn風のカスタムディレクティブをテストします。
+
+## Message（情報ボックス）
+
+:::message
+これは情報メッセージです。重要な情報やTipsを表示する際に使用します。
+
+複数行のテキストも表示できます。
+:::
+
+通常のテキストもここに書けます。
+
+## Message Alert（警告ボックス）
+
+:::message alert
+これは警告メッセージです。注意が必要な情報や、避けるべき行動などを表示する際に使用します。
+
+ユーザーの注意を引くために赤色で表示されます。
+:::
+
+## Details（折りたたみ）
+
+:::details クリックして詳細を表示
+これは折りたたみ可能なセクションです。
+
+デフォルトでは非表示になっており、タイトルをクリックすると内容が表示されます。
+
+長い説明や、補足情報、技術的な詳細などを格納するのに便利です。
+:::
+
+## 複雑な使用例
+
+:::message
+**TCP/IPの階層モデル**について学習する際は、以下の点に注意してください：
+
+- 各層の役割を理解すること
+- データの [[カプセル化]] プロセスを把握すること
+- プロトコルの動作を理解すること
+:::
+
+:::details OSI参照モデルとTCP/IPモデルの比較
+
+| OSI参照モデル | TCP/IPモデル |
+|--------------|-------------|
+| アプリケーション層 | アプリケーション層 |
+| プレゼンテーション層 | ↑ |
+| セッション層 | ↑ |
+| トランスポート層 | トランスポート層 |
+| ネットワーク層 | インターネット層 |
+| データリンク層 | ネットワークインターフェース層 |
+| 物理層 | ↑ |
+
+:::
+
+:::message alert
+**セキュリティの注意点**
+
+パスワードは必ず暗号化して保存してください。平文での保存は絶対に避けましょう。
+:::
+
+## コードブロックとの組み合わせ
+
+:::message
+以下のコードは、TypeScriptでの型定義の例です：
+
+```typescript
+interface NetworkInterface {
+  name: string;
+  ipAddress: string;
+  macAddress: string;
+}
+```
+:::
+
+:::details Pythonでのソケット通信の例
+
+```python
+import socket
+
+# サーバーの作成
+server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+server_socket.bind(('localhost', 8080))
+server_socket.listen(5)
+
+print("サーバーが起動しました")
+
+while True:
+    client_socket, address = server_socket.accept()
+    print(f"接続: {address}")
+    client_socket.close()
+```
+
+このコードは基本的なTCPサーバーの実装例です。
+:::

--- a/site/src/plugins/remark-zenn-directives.ts
+++ b/site/src/plugins/remark-zenn-directives.ts
@@ -1,0 +1,101 @@
+import { visit } from 'unist-util-visit';
+import type { Root } from 'mdast';
+import type { Plugin } from 'unified';
+import remarkDirective from 'remark-directive';
+
+/**
+ * remarkプラグイン: Zenn風のカスタムディレクティブを処理
+ *
+ * サポートするディレクティブ:
+ * 1. :::message ... ::: - 情報メッセージボックス
+ * 2. :::message alert ... ::: - 警告メッセージボックス
+ * 3. :::details タイトル ... ::: - 折りたたみ可能なセクション
+ *
+ * 使用例:
+ *   :::message
+ *   これは情報メッセージです
+ *   :::
+ *
+ *   :::message alert
+ *   これは警告メッセージです
+ *   :::
+ *
+ *   :::details クリックして詳細を表示
+ *   ここに詳細な内容が入ります
+ *   :::
+ */
+const remarkZennDirectives: Plugin<[], Root> = () => {
+  return (tree) => {
+    visit(tree, (node: any) => {
+      // containerDirective (:::) の処理
+      if (node.type === 'containerDirective') {
+        const data = node.data || (node.data = {});
+
+        // :::message または :::message alert
+        if (node.name === 'message') {
+          const isAlert = node.attributes?.alert !== undefined ||
+                         (node.children[0]?.type === 'paragraph' &&
+                          node.children[0]?.children[0]?.value === 'alert');
+
+          // 最初のテキストが "alert" の場合は削除
+          if (isAlert && node.children[0]?.type === 'paragraph' &&
+              node.children[0]?.children[0]?.value === 'alert') {
+            node.children[0].children.shift();
+            // 空になったparagraphを削除
+            if (node.children[0].children.length === 0) {
+              node.children.shift();
+            }
+          }
+
+          data.hName = 'div';
+          data.hProperties = {
+            className: isAlert ? 'zenn-message zenn-message-alert' : 'zenn-message',
+          };
+        }
+
+        // :::details タイトル
+        else if (node.name === 'details') {
+          // タイトルを取得（最初のparagraphから）
+          let title = 'Details';
+          if (node.children[0]?.type === 'paragraph') {
+            const firstChild = node.children[0].children[0];
+            if (firstChild?.type === 'text') {
+              title = firstChild.value;
+              node.children.shift(); // タイトル部分を削除
+            }
+          }
+
+          // <details> タグに変換
+          data.hName = 'details';
+          data.hProperties = {
+            className: 'zenn-details',
+          };
+
+          // <summary> タグを追加
+          node.children.unshift({
+            type: 'paragraph',
+            data: {
+              hName: 'summary',
+              hProperties: {
+                className: 'zenn-details-summary',
+              },
+            },
+            children: [
+              {
+                type: 'text',
+                value: title,
+              },
+            ],
+          });
+        }
+      }
+    });
+  };
+};
+
+/**
+ * プラグインのエクスポート
+ * directiveプラグインと組み合わせて使用する必要がある
+ */
+export default remarkZennDirectives;
+export { remarkDirective };

--- a/site/src/styles/custom.css
+++ b/site/src/styles/custom.css
@@ -70,3 +70,91 @@
   width: 4px;
   background: linear-gradient(to right, rgba(0,0,0,0.1), transparent);
 }
+
+/* Zenn-style Message Box */
+.sl-markdown-content .zenn-message {
+  padding: 1rem 1.25rem;
+  margin: 1.5rem 0;
+  border-radius: 6px;
+  border-left: 4px solid #3b82f6; /* blue-500 */
+  background-color: rgba(59, 130, 246, 0.1); /* blue-500 with opacity */
+  position: relative;
+}
+
+.sl-markdown-content .zenn-message::before {
+  content: 'ℹ️';
+  position: absolute;
+  left: 0.75rem;
+  top: 1rem;
+  font-size: 1.25rem;
+}
+
+.sl-markdown-content .zenn-message > :first-child {
+  margin-top: 0;
+  margin-left: 2rem;
+}
+
+.sl-markdown-content .zenn-message > :last-child {
+  margin-bottom: 0;
+  margin-left: 2rem;
+}
+
+/* Zenn-style Alert Message Box */
+.sl-markdown-content .zenn-message-alert {
+  border-left-color: #ef4444; /* red-500 */
+  background-color: rgba(239, 68, 68, 0.1); /* red-500 with opacity */
+}
+
+.sl-markdown-content .zenn-message-alert::before {
+  content: '⚠️';
+}
+
+/* Zenn-style Details (Collapsible) */
+.sl-markdown-content .zenn-details {
+  padding: 0;
+  margin: 1.5rem 0;
+  border: 1px solid var(--sl-color-gray-5);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.sl-markdown-content .zenn-details-summary {
+  padding: 1rem 1.25rem;
+  background-color: var(--sl-color-gray-6);
+  cursor: pointer;
+  user-select: none;
+  font-weight: 600;
+  list-style: none;
+  margin: 0;
+}
+
+.sl-markdown-content .zenn-details-summary::-webkit-details-marker {
+  display: none;
+}
+
+.sl-markdown-content .zenn-details-summary::before {
+  content: '▶';
+  display: inline-block;
+  margin-right: 0.5rem;
+  transition: transform 0.2s;
+}
+
+.sl-markdown-content .zenn-details[open] .zenn-details-summary::before {
+  transform: rotate(90deg);
+}
+
+.sl-markdown-content .zenn-details[open] .zenn-details-summary {
+  border-bottom: 1px solid var(--sl-color-gray-5);
+}
+
+.sl-markdown-content .zenn-details > :not(summary) {
+  padding: 1rem 1.25rem;
+}
+
+.sl-markdown-content .zenn-details > :not(summary):first-of-type {
+  margin-top: 0;
+}
+
+.sl-markdown-content .zenn-details > :not(summary):last-child {
+  margin-bottom: 0;
+}


### PR DESCRIPTION
Implements Zenn-like custom directives for enhanced content formatting:
- :::message - Information message boxes with blue styling
- :::message alert - Warning message boxes with red styling
- :::details - Collapsible sections with expand/collapse functionality

Changes:
- Added remark-directive package for directive parsing
- Created remark-zenn-directives plugin to transform directives
- Added CSS styles for message, alert, and details components
- Integrated plugins into astro.config.mjs
- Created test document with usage examples

https://claude.ai/code/session_01VNe9mkiSZxXY7W4FuBo5Kb